### PR TITLE
chore: fxljs first release

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,19 @@
+# Contributing to _fxl.js_
+
+First and foremost, thank you for taking an interest to contribute to _fxl.js_. This project can only improve with your help!
+
+## Release Checklist
+
+* Run test and lint tasks by running:
+	* `yarn nx run-many --all --target=test`; and
+	* `yarn nx run-many --all --target=lint`.
+* Bump the version in `packages/core/package.json`.
+* Build the library by running `yarn nx build core`.
+* Step into the dist directory and publish by running:
+	* `cd dist/packages/core`; and
+	* `yarn publish --access public`.
+* Generate the documentation page and push to `gh-pages`:
+	* `cd packages/core/src`;
+	* `npx typedoc index.ts`;
+	* check-in the resulting docs to an orphan branch; and
+	* create a PR to the `gh-pages` branch.

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const totalCells = [
 We then concatenate them, and ask _fxl.js_ to write the cells into an XLSX file:
 
 ```typescript
-import * as fxl from '@zog/fxl';
+import * as fxl from '@01group/fxl';
 
 const allCells = headerCells.concat(bodyCells).concat(totalCells);
 await fxl.writeXlsx(allCells, 'costs.xlsx')
@@ -138,7 +138,7 @@ const cells = await fxl.readXlsx('costs.xlsx')
 An important part of _fxl.js_ is the collection of shortcut functions that makes it easy to create the cell objects. We can boil down the above example to the following:
 
 ```typescript
-import * as fxl from '@zog/fxl';
+import * as fxl from '@01group/fxl';
 
 const costs = [
   { item: "Rent", cost: 1000 },
@@ -207,7 +207,7 @@ When we put our running example together, we actually see a relatively common pa
 5. finally executing the **IO** operation.
 
 ```typescript
-import * as fxl from '@zog/fxl';
+import * as fxl from '@01group/fxl';
 
 // ------------------------------------------------------------------
 // data

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ _fxl.js_ is a JavaScript adaptation of the original Clojure library [fxl](https:
 npm install @01group/fxl
 ```
 
+You may find the TypeDoc generated documentation [here](https://zero-one-group.github.io/fxl.js/modules.html).
+
 # Why _fxl.js_?
 
 There are three things that _fxl.js_ tries to do differently compared to other JavaScript spreadsheet libraries, namely:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ _fxl.js_ is a JavaScript adaptation of the original Clojure library [fxl](https:
 
 # Installation
 
-_fxl.js_ has not been released yet.
+```
+npm install @01group/fxl
+```
 
 # Why _fxl.js_?
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ const totalCells = [
 We then concatenate them, and ask _fxl.js_ to write the cells into an XLSX file:
 
 ```typescript
-import * as fxl from '@zog/fxl.js';
+import * as fxl from '@zog/fxl';
 
 const allCells = headerCells.concat(bodyCells).concat(totalCells);
 await fxl.writeXlsx(allCells, 'costs.xlsx')
@@ -138,7 +138,7 @@ const cells = await fxl.readXlsx('costs.xlsx')
 An important part of _fxl.js_ is the collection of shortcut functions that makes it easy to create the cell objects. We can boil down the above example to the following:
 
 ```typescript
-import * as fxl from '@zog/fxl.js';
+import * as fxl from '@zog/fxl';
 
 const costs = [
   { item: "Rent", cost: 1000 },
@@ -207,7 +207,7 @@ When we put our running example together, we actually see a relatively common pa
 5. finally executing the **IO** operation.
 
 ```typescript
-import * as fxl from '@zog/fxl.js';
+import * as fxl from '@zog/fxl';
 
 // ------------------------------------------------------------------
 // data

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ _fxl.js_ is a JavaScript adaptation of the original Clojure library [fxl](https:
 npm install @01group/fxl
 ```
 
-You may find the TypeDoc generated documentation [here](https://zero-one-group.github.io/fxl.js/modules.html).
+The TypeDoc generated documentation can be found [here](https://zero-one-group.github.io/fxl.js/modules.html).
 
 # Why _fxl.js_?
 
@@ -279,6 +279,8 @@ See also [ExcelJS' known issues](https://github.com/exceljs/exceljs#known-issues
 # Contributing
 
 _fxl.js_ is very much a work-in-progress. Whilst it is being used in production at [Zero One Group](www.zero-one-group.com), it may not be stable just yet. We would love your help to make it production ready! Any sort of contributions (issues, pull requests or general feedback) are all very welcomed!
+
+See the [contributing document](CONTRIBUTING.md).
 
 # Further Resources
 

--- a/docs/inventory-spreadsheet-walkthrough.md
+++ b/docs/inventory-spreadsheet-walkthrough.md
@@ -76,7 +76,7 @@ Before we start the spreadsheet building process, we first need to prepare the d
 ```typescript
 import * as fs from 'fs';
 
-import * as fxl from '@zog/fxl';
+import * as fxl from '@01group/fxl';
 
 const JSON_PATH = 'packages/example/src/assets/inventory.json';
 const RAW_DATA = fs.readFileSync(JSON_PATH).toString();

--- a/docs/inventory-spreadsheet-walkthrough.md
+++ b/docs/inventory-spreadsheet-walkthrough.md
@@ -76,6 +76,8 @@ Before we start the spreadsheet building process, we first need to prepare the d
 ```typescript
 import * as fs from 'fs';
 
+import * as fxl from '@zog/fxl';
+
 const JSON_PATH = 'packages/example/src/assets/inventory.json';
 const RAW_DATA = fs.readFileSync(JSON_PATH).toString();
 const INVENTORY = JSON.parse(RAW_DATA);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,6 @@
 {
   "name": "fxl.js",
   "version": "0.0.0",
-	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
   "license" : "Apache-2.0 License",
   "scripts": {},
   "private": true,
@@ -30,15 +29,5 @@
     "temp": "^0.9.4",
     "ts-jest": "27.0.3",
     "typescript": "~4.3.5"
-  },
-  "keywords": [
-		"curried",
-		"data-oriented",
-		"fp",
-		"functional-programming",
-		"spreadsheet",
-    "excel",
-    "xlsx"
-  ],
-	"homepage": "https://github.com/zero-one-group/fxl.js"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "fxl.js",
   "version": "0.0.0",
-  "license": "MIT",
+	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
+  "license" : "Apache-2.0 License",
   "scripts": {},
   "private": true,
   "dependencies": {
@@ -29,5 +30,15 @@
     "temp": "^0.9.4",
     "ts-jest": "27.0.3",
     "typescript": "~4.3.5"
-  }
+  },
+  "keywords": [
+		"curried",
+		"data-oriented",
+		"fp",
+		"functional-programming",
+		"spreadsheet",
+    "excel",
+    "xlsx"
+  ],
+	"homepage": "https://github.com/zero-one-group/fxl.js"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,16 @@
 {
   "name": "@zog/fxl",
-  "version": "0.0.1"
+  "version": "0.0.1",
+	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
+  "license" : "Apache-2.0 License",
+  "keywords": [
+		"curried",
+		"data-oriented",
+		"fp",
+		"functional-programming",
+		"spreadsheet",
+    "excel",
+    "xlsx"
+  ],
+	"homepage": "https://github.com/zero-one-group/fxl.js"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@01group/fxl",
-  "version": "0.0.2",
+  "version": "0.0.3",
 	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
 	"homepage": "https://github.com/zero-one-group/fxl.js",
   "dependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@01group/fxl",
-  "version": "0.0.1",
+  "version": "0.0.2",
 	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
   "license" : "Apache-2.0",
   "keywords": [

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,10 @@
   "name": "@01group/fxl",
   "version": "0.0.2",
 	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
-  "license" : "Apache-2.0",
+	"homepage": "https://github.com/zero-one-group/fxl.js",
+  "dependencies": {
+    "tslib": "^2.0.0"
+  },
   "keywords": [
 		"curried",
 		"data-oriented",
@@ -12,5 +15,5 @@
     "excel",
     "xlsx"
   ],
-	"homepage": "https://github.com/zero-one-group/fxl.js"
+  "license" : "Apache-2.0"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,6 +6,9 @@
   "dependencies": {
     "tslib": "^2.0.0"
   },
+	"engines": {
+		"node": ">=8.0.0"
+	},
   "keywords": [
 		"curried",
 		"data-oriented",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,7 +2,7 @@
   "name": "@zog/fxl",
   "version": "0.0.1",
 	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
-  "license" : "Apache-2.0 License",
+  "license" : "Apache-2.0",
   "keywords": [
 		"curried",
 		"data-oriented",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,4 +1,4 @@
 {
-  "name": "@zog/fxl.js",
+  "name": "@zog/fxl",
   "version": "0.0.1"
 }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@zog/fxl",
+  "name": "@01group/fxl",
   "version": "0.0.1",
 	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
   "license" : "Apache-2.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@01group/fxl",
-  "version": "0.0.3",
+  "version": "0.0.4",
 	"description": "fxl.js is a data-oriented JavaScript spreadsheet library. It provides a way to build spreadsheets using modular, lego-like blocks.",
 	"homepage": "https://github.com/zero-one-group/fxl.js",
   "dependencies": {

--- a/packages/core/src/lib/core.spec.ts
+++ b/packages/core/src/lib/core.spec.ts
@@ -25,12 +25,28 @@ describe('basic reading and writing xlsx', () => {
 
   it('writeXlsx should take in valid cells', async () => {
     const cell = toCell('abc');
+    const style = { colWidth: 1, rowHeight: 1 };
+    const cells = [
+      { ...cell, style: style },
+      { ...cell, coord: { row: 1, col: 0 }, style: style },
+      { ...cell, coord: { row: 0, col: 1 }, style: style },
+      {
+        ...cell,
+        coord: { row: 1, col: 1, sheet: 'abc' },
+        style: style,
+      },
+    ];
     const tempFile = temp.openSync('excel-temp');
-    await core.writeXlsx([cell], tempFile.path);
+    await core.writeXlsx(cells, tempFile.path);
     const result = await core.readXlsx(tempFile.path);
     const loadedCells = utils.extractOk(result);
-    expect(loadedCells.length).toBe(1);
-    expect(loadedCells.map((x) => x.value)).toEqual([cell.value]);
+    expect(loadedCells.length).toBe(4);
+    expect(loadedCells.map((x) => x.value)).toEqual([
+      cell.value,
+      cell.value,
+      cell.value,
+      cell.value,
+    ]);
   });
 
   it('writeXlsx should fail gracefully', async () => {

--- a/packages/core/src/lib/core.ts
+++ b/packages/core/src/lib/core.ts
@@ -54,7 +54,7 @@ export async function readXlsx(
     const cells = readExcelWorkbook(workbook);
     return Ok(cells);
   } catch (exception) {
-    return Err({ error: exception.message });
+    return Err({ error: (exception as Error).message });
   }
 }
 
@@ -77,18 +77,18 @@ export async function readBinary(
     const cells = readExcelWorkbook(workbook);
     return Ok(cells);
   } catch (exception) {
-    return Err({ error: exception.message });
+    return Err({ error: (exception as Error).message });
   }
 }
 
 function setCells(workbook: ExcelJS.Workbook, cells: t.ValidCell[]): void {
   cells.forEach((cell) => {
-    const sheetName = cell.coord.sheet || DEFAULT_SHEET_NAME;
+    const sheetName = cell.coord.sheet ?? DEFAULT_SHEET_NAME;
     const worksheet =
-      workbook.getWorksheet(sheetName) || workbook.addWorksheet(sheetName);
+      workbook.getWorksheet(sheetName) ?? workbook.addWorksheet(sheetName);
     const excelCell = worksheet.getCell(cell.coord.row + 1, cell.coord.col + 1);
     excelCell.value = cell.value;
-    excelCell.style = cell.style || {};
+    excelCell.style = cell.style ?? {};
   });
 }
 
@@ -96,20 +96,20 @@ function scanCellSizes(cells: t.Cell[]): [t.CellSizes, t.CellSizes] {
   const colWidths: t.CellSizes = new Map();
   const rowHeights: t.CellSizes = new Map();
   cells.forEach((cell) => {
-    const sheetName = cell.coord.sheet || DEFAULT_SHEET_NAME;
+    const sheetName = cell.coord.sheet ?? DEFAULT_SHEET_NAME;
     const { row: row, col: col } = cell.coord;
     const colWidth = cell.style?.colWidth;
     if (colWidth) {
-      const sheetColWidths = colWidths.get(sheetName) || new Map();
-      const thisColWidths = sheetColWidths.get(col) || [];
+      const sheetColWidths = colWidths.get(sheetName) ?? new Map();
+      const thisColWidths = sheetColWidths.get(col) ?? [];
       thisColWidths.push(colWidth);
       sheetColWidths.set(col, thisColWidths);
       colWidths.set(sheetName, sheetColWidths);
     }
     const rowHeight = cell.style?.rowHeight;
     if (rowHeight) {
-      const sheetRowHeights = rowHeights.get(sheetName) || new Map();
-      const thisRowHeights = sheetRowHeights.get(row) || [];
+      const sheetRowHeights = rowHeights.get(sheetName) ?? new Map();
+      const thisRowHeights = sheetRowHeights.get(row) ?? [];
       thisRowHeights.push(rowHeight);
       sheetRowHeights.set(col, thisRowHeights);
       rowHeights.set(sheetName, sheetRowHeights);

--- a/packages/core/src/lib/core.ts
+++ b/packages/core/src/lib/core.ts
@@ -54,6 +54,7 @@ export async function readXlsx(
     const cells = readExcelWorkbook(workbook);
     return Ok(cells);
   } catch (exception) {
+    // TODO: exception should be of type unknown
     return Err({ error: (exception as Error).message });
   }
 }
@@ -77,6 +78,7 @@ export async function readBinary(
     const cells = readExcelWorkbook(workbook);
     return Ok(cells);
   } catch (exception) {
+    // TODO: exception should be of type unknown
     return Err({ error: (exception as Error).message });
   }
 }

--- a/packages/core/src/lib/styles.ts
+++ b/packages/core/src/lib/styles.ts
@@ -97,7 +97,7 @@ export function setSolidBg(color: string): t.Monoid<t.Cell> {
 // Border Shortcuts
 // ---------------------------------------------------------------------------
 function getBorders(cell: t.Cell): t.Borders {
-  return cell.style?.border || {};
+  return cell.style?.border ?? {};
 }
 
 /**
@@ -168,7 +168,7 @@ export function toBorder(style: t.BorderStyle, color: string): t.Border {
 // Alignment Shortcuts
 // ---------------------------------------------------------------------------
 function getAlignment(cell: t.Cell): t.Alignment {
-  return cell.style?.alignment || {};
+  return cell.style?.alignment ?? {};
 }
 
 /**
@@ -231,7 +231,7 @@ export function setWrapText(wrapText: boolean): t.Monoid<t.Cell> {
 // Font Shortcuts
 // ---------------------------------------------------------------------------
 function getFont(cell: t.Cell): t.Font {
-  return cell.style?.font || {};
+  return cell.style?.font ?? {};
 }
 
 /**

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 
-import * as fxl from '@zog/fxl.js';
+import * as fxl from '@zog/fxl';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/packages/example/src/main.ts
+++ b/packages/example/src/main.ts
@@ -1,6 +1,6 @@
 import * as fs from 'fs';
 
-import * as fxl from '@zog/fxl';
+import * as fxl from '@01group/fxl';
 
 // ---------------------------------------------------------------------------
 // Types

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@zog/fxl": ["packages/core/src/index.ts"]
+      "@01group/fxl": ["packages/core/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -16,7 +16,7 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
-      "@zog/fxl.js": ["packages/core/src/index.ts"]
+      "@zog/fxl": ["packages/core/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "importHelpers": true,
+    "importHelpers": false,
     "target": "es2015",
     "module": "esnext",
     "lib": ["es2019", "dom"],

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -8,7 +8,7 @@
     "moduleResolution": "node",
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
-    "importHelpers": false,
+    "importHelpers": true,
     "target": "es2015",
     "module": "esnext",
     "lib": ["es2019", "dom"],

--- a/workspace.json
+++ b/workspace.json
@@ -30,7 +30,7 @@
             "tsConfig": "packages/core/tsconfig.lib.json",
             "packageJson": "packages/core/package.json",
             "main": "packages/core/src/index.ts",
-            "assets": ["packages/core/*.md"]
+            "assets": ["README.md"]
           }
         }
       }


### PR DESCRIPTION
@rubiagatra 

Things to consider:

* Changed our org name to `01group` because `zog` is unfortunately taken: https://www.npmjs.com/org/zog
* For some reason, when I run `yarn nx build core` the library `tslib` does not get passed on to the dist `package.json` I had to add it manually to `packages/core/package.json`. I'm not sure if this is the best solution, but works for now.

How I tested it:

```
mkdir temp && cd temp && npm init -y && npm install @01group/fxl --save 
```

Then add the `"type": "module"` pair in the `package.json` and the following script works fine:

```javascript
import * as fxl from "@01group/fxl";

console.log(fxl.toCell("abc"));
```